### PR TITLE
Update npx command to include @latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,11 @@
   "dependencies": {
     "next": "15.0.4",
     "react": "^19.0.0",
-    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^19",
-    "@types/react-copy-to-clipboard": "^5.0.7",
     "@types/react-dom": "^19",
     "eslint": "^8",
     "eslint-config-next": "15.0.4",

--- a/src/app/components/copy.tsx
+++ b/src/app/components/copy.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import CopyToClipboard from 'react-copy-to-clipboard'
 
 function CopyIcon() {
   return (
@@ -46,21 +45,22 @@ function CheckIcon() {
 
 export function Copy() {
   const [npxCommandCopied, setNpxCommandCopied] = useState(false)
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText('npx eth-tech-tree@latest')
+      setNpxCommandCopied(true)
+      setTimeout(() => {
+        setNpxCommandCopied(false)
+      }, 800)
+    } catch {
+      // no-op
+    }
+  }
   return (
     <div>
-      <CopyToClipboard
-        text={'npx eth-tech-tree'}
-        onCopy={() => {
-          setNpxCommandCopied(true)
-          setTimeout(() => {
-            setNpxCommandCopied(false)
-          }, 800)
-        }}
-      >
-        <button className="">
-          {npxCommandCopied ? <CheckIcon /> : <CopyIcon />}
-        </button>
-      </CopyToClipboard>
+      <button className="" onClick={handleCopy}>
+        {npxCommandCopied ? <CheckIcon /> : <CopyIcon />}
+      </button>
     </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function Home() {
             <div className="p-4 bg-slate-800 border-t border-gray-700 rounded-b-md">
               <pre className="text-lg">
                 <code>
-                  npx <span className="text-green-400">eth-tech-tree</span>
+                  npx <span className="text-green-400">eth-tech-tree@latest</span>
                 </code>
               </pre>
             </div>


### PR DESCRIPTION
Updates the `npx` command to include `@latest` and replaces `react-copy-to-clipboard` with native clipboard API to resolve a React 19 peer dependency conflict.

The `react-copy-to-clipboard` package caused a peer dependency conflict with React 19, which prevented a clean build. Switching to `navigator.clipboard` resolves this issue while maintaining copy functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-e040d641-0627-4480-8f41-ea5bc817dc63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e040d641-0627-4480-8f41-ea5bc817dc63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

